### PR TITLE
Update:Fixed CRC error.

### DIFF
--- a/linux-marvell/arch/arm64/boot/dts/marvell/armada-3720-catdrive.dts
+++ b/linux-marvell/arch/arm64/boot/dts/marvell/armada-3720-catdrive.dts
@@ -106,6 +106,7 @@
 	status = "okay";
 	phy0: ethernet-phy@0 {
 		reg = <0>;
+		marvell,reg-init = <0x01 0x1A 0x0 0x47>;
 	};
 };
 


### PR DESCRIPTION
There is a wide discussion about random "CRC Error" in dmesg messages.  
According to https://blog.csdn.net/qq_33205540/article/details/107098898 it might because of some faults in electrical designing.  
Setting power peak value higher will solve this error.  
Tested for about 2 weeks and everything is fine.   